### PR TITLE
Make trace headers case insensitive

### DIFF
--- a/src/trace/context.spec.ts
+++ b/src/trace/context.spec.ts
@@ -1,8 +1,13 @@
 import { LogLevel, setLogLevel } from "../utils";
 import { SampleMode } from "./constants";
 import {
-    convertToAPMParentID, convertToAPMTraceID, convertToSampleMode, convertTraceContext,
-    extractTraceContext, readTraceContextFromXray, readTraceFromEvent
+  convertToAPMParentID,
+  convertToAPMTraceID,
+  convertToSampleMode,
+  convertTraceContext,
+  extractTraceContext,
+  readTraceContextFromXray,
+  readTraceFromEvent,
 } from "./context";
 
 let currentSegment: any;
@@ -156,6 +161,20 @@ describe("readTraceFromEvent", () => {
         "x-datadog-parent-id": "797643193680388254",
         "x-datadog-sampling-priority": "2",
         "x-datadog-trace-id": "4110911582297405557",
+      },
+    });
+    expect(result).toEqual({
+      parentID: "797643193680388254",
+      sampleMode: SampleMode.USER_KEEP,
+      traceID: "4110911582297405557",
+    });
+  });
+  it("can read well formed headers with mixed casing", () => {
+    const result = readTraceFromEvent({
+      headers: {
+        "X-Datadog-Parent-Id": "797643193680388254",
+        "X-Datadog-Sampling-Priority": "2",
+        "X-Datadog-Trace-Id": "4110911582297405557",
       },
     });
     expect(result).toEqual({

--- a/src/trace/context.ts
+++ b/src/trace/context.ts
@@ -64,13 +64,11 @@ export function readTraceFromEvent(event: any): TraceContext | undefined {
     return;
   }
 
-  const lowerCaseHeaders = Object.keys(headers).reduce(
-    (prev, header) => {
-      prev[header.toLocaleLowerCase()] = headers[header];
-      return prev;
-    },
-    {} as { [key: string]: string },
-  );
+  const lowerCaseHeaders: { [key: string]: string } = {};
+
+  for (const key of Object.keys(headers)) {
+    lowerCaseHeaders[key.toLocaleLowerCase()] = headers[key];
+  }
 
   const traceID = lowerCaseHeaders[traceIDHeader];
   if (typeof traceID !== "string") {

--- a/src/trace/context.ts
+++ b/src/trace/context.ts
@@ -3,8 +3,13 @@ import { BigNumber } from "bignumber.js";
 
 import { logError } from "../utils";
 import {
-    parentIDHeader, SampleMode, samplingPriorityHeader, traceIDHeader, xraySubsegmentKey,
-    xraySubsegmentName, xraySubsegmentNamespace
+  parentIDHeader,
+  SampleMode,
+  samplingPriorityHeader,
+  traceIDHeader,
+  xraySubsegmentKey,
+  xraySubsegmentName,
+  xraySubsegmentNamespace,
 } from "./constants";
 
 export interface XRayTraceHeader {
@@ -58,15 +63,24 @@ export function readTraceFromEvent(event: any): TraceContext | undefined {
   if (typeof headers !== "object") {
     return;
   }
-  const traceID = headers[traceIDHeader];
+
+  const lowerCaseHeaders = Object.keys(headers).reduce(
+    (prev, header) => {
+      prev[header.toLocaleLowerCase()] = headers[header];
+      return prev;
+    },
+    {} as { [key: string]: string },
+  );
+
+  const traceID = lowerCaseHeaders[traceIDHeader];
   if (typeof traceID !== "string") {
     return;
   }
-  const parentID = headers[parentIDHeader];
+  const parentID = lowerCaseHeaders[parentIDHeader];
   if (typeof parentID !== "string") {
     return;
   }
-  const sampledHeader = headers[samplingPriorityHeader];
+  const sampledHeader = lowerCaseHeaders[samplingPriorityHeader];
   if (typeof sampledHeader !== "string") {
     return;
   }


### PR DESCRIPTION
*Note: Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-layer-js/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Reads trace headers with case insensitivity.

### Motivation

We were having an issue with some frameworks which would force mixed casing.

### Testing Guidelines

How did you test this pull request?

### Additional Notes

Anything else we should know when reviewing?
