### PR TITLE
Add enhanced lambda metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ How much logging datadog-lambda-layer-js should do. Set this to "debug" for exte
 
 If you have the Datadog Lambda Log forwarder enabled and are sending custom metrics, set this to true so your metrics will be sent via logs, (instead of being sent at the end of your lambda invocation).
 
+### DD_ENHANCED_METRICS
+
+If you set the value of this variable to "true" then the Lambda layer will increment a Lambda integration metric called `aws.lambda.enhanced.invocations` with each invocation and `aws.lambda.enhanced.errors` if the invocation results in an error. These metrics are tagged with the function name, region, and account, as well as `cold_start:true|false`.
+
 ## Usage
 
 Datadog needs to be able to read headers from the incoming Lambda event.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datadog-lambda-js",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Lambda client library that supports hybrid tracing in node js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/metrics/enhanced-lambda-metrics.ts
+++ b/src/metrics/enhanced-lambda-metrics.ts
@@ -1,0 +1,16 @@
+import { sendDistributionMetric } from "../index";
+
+import { parseTagsFromARN } from "../utils/arn";
+import { getColdStartTag } from "../utils/cold-start";
+
+const ENHANCED_LAMBDA_METRICS_NAMESPACE = "aws.lambda.enhanced";
+
+export function incrementInvocationsMetric(functionARN: string): void {
+  const tags = [...parseTagsFromARN(functionARN), getColdStartTag()];
+  sendDistributionMetric(`${ENHANCED_LAMBDA_METRICS_NAMESPACE}.invocations`, 1, ...tags);
+}
+
+export function incrementErrorsMetric(functionARN: string): void {
+  const tags = [...parseTagsFromARN(functionARN), getColdStartTag()];
+  sendDistributionMetric(`${ENHANCED_LAMBDA_METRICS_NAMESPACE}.errors`, 1, ...tags);
+}

--- a/src/metrics/enhanced-metrics.ts
+++ b/src/metrics/enhanced-metrics.ts
@@ -5,22 +5,12 @@ import { getColdStartTag } from "../utils/cold-start";
 
 const ENHANCED_LAMBDA_METRICS_NAMESPACE = "aws.lambda.enhanced";
 
-function areEnhancedMetricsEnabled() {
-  return getEnvValue("DD_ENHANCED_METRICS", "false").toLowerCase() === "true";
-}
-
 export function incrementInvocationsMetric(functionARN: string): void {
-  if (!areEnhancedMetricsEnabled()) {
-    return;
-  }
   const tags = [...parseTagsFromARN(functionARN), getColdStartTag()];
   sendDistributionMetric(`${ENHANCED_LAMBDA_METRICS_NAMESPACE}.invocations`, 1, ...tags);
 }
 
 export function incrementErrorsMetric(functionARN: string): void {
-  if (!areEnhancedMetricsEnabled()) {
-    return;
-  }
   const tags = [...parseTagsFromARN(functionARN), getColdStartTag()];
   sendDistributionMetric(`${ENHANCED_LAMBDA_METRICS_NAMESPACE}.errors`, 1, ...tags);
 }

--- a/src/metrics/enhanced-metrics.ts
+++ b/src/metrics/enhanced-metrics.ts
@@ -1,16 +1,26 @@
-import { sendDistributionMetric } from "../index";
+import { getEnvValue, sendDistributionMetric } from "../index";
 
 import { parseTagsFromARN } from "../utils/arn";
 import { getColdStartTag } from "../utils/cold-start";
 
 const ENHANCED_LAMBDA_METRICS_NAMESPACE = "aws.lambda.enhanced";
 
+function areEnhancedMetricsEnabled() {
+  return getEnvValue("DD_ENHANCED_METRICS", "false").toLowerCase() === "true";
+}
+
 export function incrementInvocationsMetric(functionARN: string): void {
+  if (!areEnhancedMetricsEnabled()) {
+    return;
+  }
   const tags = [...parseTagsFromARN(functionARN), getColdStartTag()];
   sendDistributionMetric(`${ENHANCED_LAMBDA_METRICS_NAMESPACE}.invocations`, 1, ...tags);
 }
 
 export function incrementErrorsMetric(functionARN: string): void {
+  if (!areEnhancedMetricsEnabled()) {
+    return;
+  }
   const tags = [...parseTagsFromARN(functionARN), getColdStartTag()];
   sendDistributionMetric(`${ENHANCED_LAMBDA_METRICS_NAMESPACE}.errors`, 1, ...tags);
 }

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -1,2 +1,3 @@
 export { MetricsConfig, MetricsListener } from "./listener";
 export { KMSService } from "./kms-service";
+export { incrementErrorsMetric, incrementInvocationsMetric } from "./enhanced-metrics";

--- a/src/metrics/listener.spec.ts
+++ b/src/metrics/listener.spec.ts
@@ -26,6 +26,7 @@ describe("MetricsListener", () => {
     const listener = new MetricsListener(kms as any, {
       apiKey: "api-key",
       apiKeyKMS: "kms-api-key-encrypted",
+      enhancedMetrics: false,
       logForwarding: false,
       shouldRetryMetrics: false,
       siteURL,
@@ -46,6 +47,7 @@ describe("MetricsListener", () => {
     const listener = new MetricsListener(kms as any, {
       apiKey: "",
       apiKeyKMS: "kms-api-key-encrypted",
+      enhancedMetrics: false,
       logForwarding: false,
       shouldRetryMetrics: false,
       siteURL,
@@ -62,6 +64,7 @@ describe("MetricsListener", () => {
     const listener = new MetricsListener(kms as any, {
       apiKey: "",
       apiKeyKMS: "kms-api-key-encrypted",
+      enhancedMetrics: false,
       logForwarding: false,
       shouldRetryMetrics: false,
       siteURL,

--- a/src/metrics/listener.ts
+++ b/src/metrics/listener.ts
@@ -38,6 +38,12 @@ export interface MetricsConfig {
    * @default false
    */
   logForwarding: boolean;
+
+  /**
+   * Whether to increment invocations and errors Lambda integration metrics from this layer.
+   * @default false
+   */
+  enhancedMetrics: boolean;
 }
 
 export class MetricsListener {

--- a/src/utils/arn.spec.ts
+++ b/src/utils/arn.spec.ts
@@ -1,0 +1,35 @@
+import { parseLambdaARN, parseTagsFromARN } from "./arn";
+
+describe("arn utils", () => {
+  it("parses arn properties", () => {
+    expect(parseLambdaARN("arn:aws:lambda:us-east-1:123497598159:function:my-test-lambda")).toEqual({
+      account_id: "123497598159",
+      functionname: "my-test-lambda",
+      region: "us-east-1",
+    });
+  });
+
+  it("parses arn properties with version alias", () => {
+    expect(parseLambdaARN("arn:aws:lambda:us-east-1:123497598159:function:my-test-lambda:my-version-alias")).toEqual({
+      account_id: "123497598159",
+      functionname: "my-test-lambda",
+      region: "us-east-1",
+    });
+  });
+
+  it("parses arn tags", () => {
+    const parsedTags = parseTagsFromARN("arn:aws:lambda:us-east-1:123497598159:function:my-test-lambda");
+    for (const tag of ["account_id:123497598159", "functionname:my-test-lambda", "region:us-east-1"]) {
+      expect(parsedTags).toContain(tag);
+    }
+  });
+
+  it("parses arn tags with version", () => {
+    const parsedTags = parseTagsFromARN(
+      "arn:aws:lambda:us-east-1:123497598159:function:my-test-lambda:my-version-alias",
+    );
+    for (const tag of ["account_id:123497598159", "functionname:my-test-lambda", "region:us-east-1"]) {
+      expect(parsedTags).toContain(tag);
+    }
+  });
+});

--- a/src/utils/arn.ts
+++ b/src/utils/arn.ts
@@ -1,0 +1,20 @@
+/** Parse properties of the ARN into an object */
+export function parseLambdaARN(functionARN: string) {
+  // Disabling variable name because account_id is the key we need to use for the tag
+  // tslint:disable-next-line: variable-name
+  const [, , , region, account_id, , functionname] = functionARN.split(":", 7);
+  return { region, account_id, functionname };
+}
+
+/**
+ * Parse keyValueObject to get the array of key:value strings to use in Datadog metric submission
+ * @param obj The object whose properties and values we want to get key:value strings from
+ */
+function makeTagStringsFromObject(keyValueObject: { [key: string]: string }) {
+  return Object.entries(keyValueObject).map(([tagKey, tagValue]) => `${tagKey}:${tagValue}`);
+}
+
+/** Get the array of "key:value" string tags from the Lambda ARN */
+export function parseTagsFromARN(functionARN: string) {
+  return makeTagStringsFromObject(parseLambdaARN(functionARN));
+}

--- a/src/utils/cold-start.spec.ts
+++ b/src/utils/cold-start.spec.ts
@@ -1,0 +1,22 @@
+import { _resetColdStart, didFunctionColdStart, setColdStart } from "./cold-start";
+
+beforeEach(_resetColdStart);
+afterAll(_resetColdStart);
+
+describe("cold-start", () => {
+  it("identifies cold starts on the first execution", () => {
+    setColdStart();
+    expect(didFunctionColdStart()).toEqual(true);
+  });
+
+  it("identifies non-cold starts on subsequent executions", () => {
+    setColdStart();
+    expect(didFunctionColdStart()).toEqual(true);
+
+    setColdStart();
+    expect(didFunctionColdStart()).toEqual(false);
+
+    setColdStart();
+    expect(didFunctionColdStart()).toEqual(false);
+  });
+});

--- a/src/utils/cold-start.ts
+++ b/src/utils/cold-start.ts
@@ -1,0 +1,27 @@
+let _didFunctionColdStart = true;
+
+let _isColdStartSet = false;
+
+/**
+ * Use global variables to determine whether the container cold started
+ * On the first container run, _isColdStartSet and _didFunctionColdStart are true
+ * For subsequent executions _isColdStartSet will be true and _didFunctionColdStart will be false
+ */
+export function setColdStart() {
+  _didFunctionColdStart = !_isColdStartSet;
+  _isColdStartSet = true;
+}
+
+export function didFunctionColdStart() {
+  return _didFunctionColdStart;
+}
+
+export function getColdStartTag() {
+  return `cold_start:${didFunctionColdStart()}`;
+}
+
+// For testing, reset the globals to their original values
+export function _resetColdStart() {
+  _didFunctionColdStart = true;
+  _isColdStartSet = false;
+}

--- a/src/utils/cold-start.ts
+++ b/src/utils/cold-start.ts
@@ -1,19 +1,19 @@
-let _didFunctionColdStart = true;
+let functionDidColdStart = true;
 
-let _isColdStartSet = false;
+let isColdStartSet = false;
 
 /**
  * Use global variables to determine whether the container cold started
- * On the first container run, _isColdStartSet and _didFunctionColdStart are true
- * For subsequent executions _isColdStartSet will be true and _didFunctionColdStart will be false
+ * On the first container run, isColdStartSet and functionDidColdStart are true
+ * For subsequent executions isColdStartSet will be true and functionDidColdStart will be false
  */
 export function setColdStart() {
-  _didFunctionColdStart = !_isColdStartSet;
-  _isColdStartSet = true;
+  functionDidColdStart = !isColdStartSet;
+  isColdStartSet = true;
 }
 
 export function didFunctionColdStart() {
-  return _didFunctionColdStart;
+  return functionDidColdStart;
 }
 
 export function getColdStartTag() {
@@ -22,6 +22,6 @@ export function getColdStartTag() {
 
 // For testing, reset the globals to their original values
 export function _resetColdStart() {
-  _didFunctionColdStart = true;
-  _isColdStartSet = false;
+  functionDidColdStart = true;
+  isColdStartSet = false;
 }

--- a/src/utils/handler.spec.ts
+++ b/src/utils/handler.spec.ts
@@ -4,16 +4,6 @@ import { didFunctionColdStart } from "./cold-start";
 import { wrap } from "./handler";
 import { LogLevel, setLogLevel } from "./log";
 
-import { sendDistributionMetric } from "../index";
-
-jest.mock("../index");
-
-const mockedSendDistributionMetric = sendDistributionMetric as jest.Mock<typeof sendDistributionMetric>;
-
-afterEach(() => {
-  mockedSendDistributionMetric.mockClear();
-});
-
 const mockContext = ({
   invokedFunctionArn: "arn:aws:lambda:us-east-1:123497598159:function:my-test-lambda",
 } as any) as Context;
@@ -196,60 +186,5 @@ describe("wrap", () => {
     expect(calledStart).toBeTruthy();
     expect(calledComplete).toBeTruthy();
     expect(calledOriginalHandler).toBeFalsy();
-  });
-
-  it("increments invocations for each function call", async () => {
-    const handler: Handler = (event, context, callback) => {
-      callback(null, { statusCode: 200, body: "The body of the response" });
-    };
-
-    const wrappedHandler = wrap(handler, () => {}, async () => {});
-
-    await wrappedHandler({}, mockContext, () => {});
-
-    expect(mockedSendDistributionMetric).toBeCalledTimes(1);
-    expect(mockedSendDistributionMetric).toBeCalledWith(
-      "aws.lambda.enhanced.invocations",
-      1,
-      "region:us-east-1",
-      "account_id:123497598159",
-      "functionname:my-test-lambda",
-      "cold_start:true",
-    );
-
-    await wrappedHandler({}, mockContext, () => {});
-    await wrappedHandler({}, mockContext, () => {});
-    await wrappedHandler({}, mockContext, () => {});
-
-    expect(mockedSendDistributionMetric).toBeCalledTimes(4);
-  });
-
-  it("increments errors correctly", async () => {
-    const handler: Handler = (event, context, callback) => {
-      throw Error("Some error");
-    };
-
-    const wrappedHandler = wrap(handler, () => {}, async () => {});
-
-    const result = wrappedHandler({}, mockContext, () => {});
-    await expect(result).rejects.toEqual(Error("Some error"));
-
-    expect(mockedSendDistributionMetric).toBeCalledTimes(2);
-    expect(mockedSendDistributionMetric).toBeCalledWith(
-      "aws.lambda.enhanced.invocations",
-      1,
-      "region:us-east-1",
-      "account_id:123497598159",
-      "functionname:my-test-lambda",
-      "cold_start:true",
-    );
-    expect(mockedSendDistributionMetric).toBeCalledWith(
-      "aws.lambda.enhanced.errors",
-      1,
-      "region:us-east-1",
-      "account_id:123497598159",
-      "functionname:my-test-lambda",
-      "cold_start:true",
-    );
   });
 });

--- a/src/utils/handler.ts
+++ b/src/utils/handler.ts
@@ -1,6 +1,5 @@
 import { Callback, Context, Handler } from "aws-lambda";
 
-import { incrementErrorsMetric, incrementInvocationsMetric } from "../metrics/enhanced-lambda-metrics";
 import { logError } from "./log";
 
 export type OnWrapFunc<T = (...args: any[]) => any> = (fn: T) => T;
@@ -11,7 +10,7 @@ export type OnWrapFunc<T = (...args: any[]) => any> = (fn: T) => T;
 export function wrap<TEvent, TResult>(
   handler: Handler<TEvent, TResult>,
   onStart: (event: TEvent, context: Context) => void,
-  onComplete: () => Promise<void>,
+  onComplete: (event: TEvent, context: Context, error?: Error) => Promise<void>,
   onWrap?: OnWrapFunc,
 ): Handler<TEvent, TResult> {
   const promHandler = promisifiedHandler(handler);
@@ -19,21 +18,29 @@ export function wrap<TEvent, TResult>(
   return async (event: TEvent, context: Context) => {
     try {
       await onStart(event, context);
-      incrementInvocationsMetric(context.invokedFunctionArn);
     } catch (error) {
       // Swallow the error and continue processing.
       logError("Pre-lambda hook threw error", { innerError: error });
     }
     let result: TResult;
+    // Need to disable linter rule to explicitly assign the variable, otherwise TS
+    // won't reccognize that the var may be assigned in the catch block
+    // tslint:disable-next-line: no-unnecessary-initializer
+    let handlerError: Error | undefined = undefined;
+
     try {
       const wrappedHandler = onWrap !== undefined ? onWrap(promHandler) : promHandler;
       result = await wrappedHandler(event, context);
     } catch (error) {
-      incrementErrorsMetric(context.invokedFunctionArn);
+      handlerError = error;
       throw error;
     } finally {
       try {
-        await onComplete();
+        if (handlerError) {
+          await onComplete(event, context, handlerError);
+        } else {
+          await onComplete(event, context);
+        }
       } catch (error) {
         // Swallow the error and continue processing.
         logError("Post-lambda hook threw error", { innerError: error });


### PR DESCRIPTION
### What does this PR do?

Increments the `aws.lambda.enhanced.invocations` distribution metric on each function call and increments `aws.lambda.enhanced.errors` when the Lambda handler throws an exception.

### Testing Guidelines

Unit tests for the metrics, currently adding the updated layer to functions in the demo account.
