### PR TITLE
Darcy.rayner/fix timeout no return

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datadog-lambda-js",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Lambda client library that supports hybrid tracing in node js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/metrics/listener.ts
+++ b/src/metrics/listener.ts
@@ -1,6 +1,6 @@
 import { promisify } from "util";
 
-import { logError } from "../utils";
+import { logError, logDebug } from "../utils";
 import { APIClient } from "./api";
 import { KMSService } from "./kms-service";
 import { Distribution } from "./model";
@@ -55,6 +55,9 @@ export class MetricsListener {
   }
 
   public onStartInvocation(_: any) {
+    if (this.config.logForwarding) {
+      return;
+    }
     this.currentProcessor = this.createProcessor(this.config, this.apiKey);
   }
 
@@ -124,8 +127,13 @@ export class MetricsListener {
       } catch (error) {
         logError("couldn't decrypt kms api key", { innerError: error });
       }
-    } else {
-      logError("api key not configured");
+    } else if (!config.logForwarding) {
+      const errorMessage = "api key not configured, see https://dtdg.co/sls-node-metrics";
+      if (config.logForwarding) {
+        logDebug(errorMessage);
+      } else {
+        logError(errorMessage);
+      }
     }
     return "";
   }

--- a/src/metrics/listener.ts
+++ b/src/metrics/listener.ts
@@ -1,6 +1,6 @@
 import { promisify } from "util";
 
-import { logError, logDebug } from "../utils";
+import { logDebug, logError } from "../utils";
 import { APIClient } from "./api";
 import { KMSService } from "./kms-service";
 import { Distribution } from "./model";

--- a/src/utils/handler.spec.ts
+++ b/src/utils/handler.spec.ts
@@ -205,4 +205,24 @@ describe("wrap", () => {
     expect(result).toEqual({ statusCode: 204, body: "The callback response" });
     expect(calledOriginalHandler).toBeFalsy();
   });
+
+  it("doesn't complete using non-promise return values", async () => {
+    const handler: Handler = (event, context, callback) => {
+      setTimeout(() => {
+        callback(null, { statusCode: 204, body: "The callback response" });
+      }, 10);
+      return ({ statusCode: 200, body: "The promise response" } as unknown) as void;
+    };
+
+    let calledOriginalHandler = false;
+
+    const wrappedHandler = wrap(handler, () => {}, async () => {});
+
+    const result = await wrappedHandler({}, mockContext, () => {
+      calledOriginalHandler = true;
+    });
+
+    expect(result).toEqual({ statusCode: 204, body: "The callback response" });
+    expect(calledOriginalHandler).toBeFalsy();
+  });
 });

--- a/src/utils/handler.spec.ts
+++ b/src/utils/handler.spec.ts
@@ -187,4 +187,22 @@ describe("wrap", () => {
     expect(calledComplete).toBeTruthy();
     expect(calledOriginalHandler).toBeFalsy();
   });
+
+  it("returns the first result to complete between the callback and the handler promise", async () => {
+    const handler: Handler = async (event, context, callback) => {
+      callback(null, { statusCode: 204, body: "The callback response" });
+      return { statusCode: 200, body: "The promise response" };
+    };
+
+    let calledOriginalHandler = false;
+
+    const wrappedHandler = wrap(handler, () => {}, async () => {});
+
+    const result = await wrappedHandler({}, mockContext, () => {
+      calledOriginalHandler = true;
+    });
+
+    expect(result).toEqual({ statusCode: 204, body: "The callback response" });
+    expect(calledOriginalHandler).toBeFalsy();
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Fixes the behavior of the handler wrapper to match the lambda node runtime in the following cases:
- Handlers that never return a value will no longer block until timeout
- Handlers that return a non promise value will have their return values ignored
- Handlers the use the callback, and return a promise, will return with the first to complete

### Motivation
Issue #32 

### Testing Guidelines

Added test cases, and manual testing.
