### PR TITLE
Darcy.rayner/support parentless trace

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,9 +41,9 @@ export const defaultConfig: Config = {
   debugLogging: false,
   enhancedMetrics: false,
   logForwarding: false,
+  mergeDatadogXrayTraces: false,
   shouldRetryMetrics: false,
   siteURL: "",
-  mergeDatadogXrayTraces: false,
 } as const;
 
 let currentMetricsListener: MetricsListener | undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ export const defaultConfig: Config = {
   logForwarding: false,
   shouldRetryMetrics: false,
   siteURL: "",
+  mergeDatadogXrayTraces: false,
 } as const;
 
 let currentMetricsListener: MetricsListener | undefined;

--- a/src/trace/constants.ts
+++ b/src/trace/constants.ts
@@ -4,6 +4,10 @@ export enum SampleMode {
   AUTO_KEEP = 1,
   USER_KEEP = 2,
 }
+export enum Source {
+  Xray = "xray",
+  Event = "event",
+}
 
 export const traceIDHeader = "x-datadog-trace-id";
 export const parentIDHeader = "x-datadog-parent-id";

--- a/src/trace/context.spec.ts
+++ b/src/trace/context.spec.ts
@@ -1,5 +1,5 @@
 import { LogLevel, setLogLevel } from "../utils";
-import { SampleMode, xrayBaggageSubsegmentKey, xraySubsegmentNamespace } from "./constants";
+import { SampleMode, xrayBaggageSubsegmentKey, xraySubsegmentNamespace, Source } from "./constants";
 import {
   convertToAPMParentID,
   convertToAPMTraceID,
@@ -105,6 +105,7 @@ describe("convertTraceContext", () => {
       parentID: "797643193680388254",
       sampleMode: SampleMode.USER_KEEP,
       traceID: "4110911582297405557",
+      source: Source.Xray,
     });
   });
   it("returns undefined if traceID is invalid", () => {
@@ -137,9 +138,10 @@ describe("readTraceContextFromXray", () => {
       parentID: "797643193680388254",
       sampleMode: SampleMode.USER_KEEP,
       traceID: "4110911582297405557",
+      source: Source.Xray,
     });
   });
-  it("will parse a trace context from the xray, with sampling turned off", () => {
+  it("will ignore a trace context from the xray, when sampling is turned off", () => {
     currentSegment = {
       id: "0b11cc4230d3e09e",
       notTraced: true,
@@ -151,6 +153,7 @@ describe("readTraceContextFromXray", () => {
       parentID: "797643193680388254",
       sampleMode: SampleMode.USER_REJECT,
       traceID: "4110911582297405557",
+      source: Source.Xray,
     });
   });
   it("returns undefined when trace header isn't in environment", () => {
@@ -172,6 +175,7 @@ describe("readTraceFromEvent", () => {
       parentID: "797643193680388254",
       sampleMode: SampleMode.USER_KEEP,
       traceID: "4110911582297405557",
+      source: Source.Event,
     });
   });
   it("can read well formed headers with mixed casing", () => {
@@ -186,6 +190,7 @@ describe("readTraceFromEvent", () => {
       parentID: "797643193680388254",
       sampleMode: SampleMode.USER_KEEP,
       traceID: "4110911582297405557",
+      source: Source.Event,
     });
   });
   it("returns undefined when missing trace id", () => {
@@ -373,6 +378,7 @@ describe("extractTraceContext", () => {
       parentID: "797643193680388251",
       sampleMode: SampleMode.USER_KEEP,
       traceID: "4110911582297405551",
+      source: Source.Event,
     });
   });
   it("returns trace read from env if no headers present", () => {
@@ -386,6 +392,7 @@ describe("extractTraceContext", () => {
       parentID: "797643193680388254",
       sampleMode: SampleMode.USER_KEEP,
       traceID: "4110911582297405557",
+      source: "xray",
     });
   });
   it("returns trace read from env if no headers present", () => {
@@ -399,6 +406,7 @@ describe("extractTraceContext", () => {
       parentID: "797643193680388254",
       sampleMode: SampleMode.USER_KEEP,
       traceID: "4110911582297405557",
+      source: "xray",
     });
   });
 

--- a/src/trace/context.ts
+++ b/src/trace/context.ts
@@ -11,6 +11,7 @@ import {
   xraySubsegmentKey,
   xraySubsegmentName,
   xraySubsegmentNamespace,
+  Source,
 } from "./constants";
 
 export interface XRayTraceHeader {
@@ -23,6 +24,7 @@ export interface TraceContext {
   traceID: string;
   parentID: string;
   sampleMode: SampleMode;
+  source: Source;
 }
 
 export interface StepFunctionContext {
@@ -111,6 +113,7 @@ export function readTraceFromEvent(event: any): TraceContext | undefined {
     parentID,
     sampleMode,
     traceID,
+    source: Source.Event,
   };
 }
 
@@ -190,6 +193,7 @@ export function convertTraceContext(traceHeader: XRayTraceHeader): TraceContext 
     parentID,
     sampleMode,
     traceID,
+    source: Source.Xray,
   };
 }
 

--- a/src/trace/context.ts
+++ b/src/trace/context.ts
@@ -6,12 +6,12 @@ import {
   parentIDHeader,
   SampleMode,
   samplingPriorityHeader,
+  Source,
   traceIDHeader,
   xrayBaggageSubsegmentKey,
   xraySubsegmentKey,
   xraySubsegmentName,
   xraySubsegmentNamespace,
-  Source,
 } from "./constants";
 
 export interface XRayTraceHeader {
@@ -112,8 +112,8 @@ export function readTraceFromEvent(event: any): TraceContext | undefined {
   return {
     parentID,
     sampleMode,
-    traceID,
     source: Source.Event,
+    traceID,
   };
 }
 
@@ -192,8 +192,8 @@ export function convertTraceContext(traceHeader: XRayTraceHeader): TraceContext 
   return {
     parentID,
     sampleMode,
-    traceID,
     source: Source.Xray,
+    traceID,
   };
 }
 

--- a/src/trace/dd-trace-utils.spec.ts
+++ b/src/trace/dd-trace-utils.spec.ts
@@ -1,0 +1,20 @@
+describe("isTracerInitialised", () => {
+  let isTracerInitialised: () => boolean;
+  let tracer: any;
+  beforeEach(() => {
+    isTracerInitialised = require("./dd-trace-utils").isTracerInitialised;
+    tracer = require("dd-trace");
+    process.env["AWS_LAMBDA_FUNCTION_NAME"] = "my-lambda";
+  });
+  afterEach(() => {
+    jest.resetModules();
+    delete process.env["AWS_LAMBDA_FUNCTION_NAME"];
+  });
+  it("should return true when tracer has been initialised", () => {
+    tracer.init();
+    expect(isTracerInitialised()).toBeTruthy();
+  });
+  it("should return false when tracer hasn't been initialised", () => {
+    expect(isTracerInitialised()).toBeFalsy();
+  });
+});

--- a/src/trace/dd-trace-utils.spec.ts
+++ b/src/trace/dd-trace-utils.spec.ts
@@ -1,8 +1,8 @@
-describe("isTracerInitialised", () => {
-  let isTracerInitialised: () => boolean;
+describe("isTracerInitialized", () => {
+  let isTracerInitialized: () => boolean;
   let tracer: any;
   beforeEach(() => {
-    isTracerInitialised = require("./dd-trace-utils").isTracerInitialised;
+    isTracerInitialized = require("./dd-trace-utils").isTracerInitialized;
     tracer = require("dd-trace");
     process.env["AWS_LAMBDA_FUNCTION_NAME"] = "my-lambda";
   });
@@ -12,9 +12,9 @@ describe("isTracerInitialised", () => {
   });
   it("should return true when tracer has been initialised", () => {
     tracer.init();
-    expect(isTracerInitialised()).toBeTruthy();
+    expect(isTracerInitialized()).toBeTruthy();
   });
   it("should return false when tracer hasn't been initialised", () => {
-    expect(isTracerInitialised()).toBeFalsy();
+    expect(isTracerInitialized()).toBeFalsy();
   });
 });

--- a/src/trace/dd-trace-utils.ts
+++ b/src/trace/dd-trace-utils.ts
@@ -2,5 +2,6 @@ import Tracer from "dd-trace";
 
 export function isTracerInitialized() {
   // TODO, waiting for a better way from APM to tell whether tracer has been initialised.
-  return "_service" in (Tracer as any)._tracer;
+  const tracer = Tracer as any;
+  return tracer !== undefined && tracer._tracer !== undefined && "_service" in tracer._tracer;
 }

--- a/src/trace/dd-trace-utils.ts
+++ b/src/trace/dd-trace-utils.ts
@@ -1,0 +1,6 @@
+import Tracer from "dd-trace";
+
+export function isTracerInitialised() {
+  // TODO, waiting for a better way from APM to tell whether tracer has been initialised.
+  return "_service" in (Tracer as any)._tracer;
+}

--- a/src/trace/dd-trace-utils.ts
+++ b/src/trace/dd-trace-utils.ts
@@ -1,6 +1,6 @@
 import Tracer from "dd-trace";
 
-export function isTracerInitialised() {
+export function isTracerInitialized() {
   // TODO, waiting for a better way from APM to tell whether tracer has been initialised.
   return "_service" in (Tracer as any)._tracer;
 }

--- a/src/trace/listener.spec.ts
+++ b/src/trace/listener.spec.ts
@@ -1,0 +1,159 @@
+import { TraceListener } from "./listener";
+import { Source } from "./constants";
+
+let mockWrap: jest.Mock<any, any>;
+let mockExtract: jest.Mock<any, any>;
+let mockTraceHeaders: Record<string, string> | undefined = undefined;
+let mockTraceSource: Source | undefined = undefined;
+
+jest.mock("dd-trace", () => {
+  mockWrap = jest.fn().mockImplementation((name, options, func) => func);
+  mockExtract = jest.fn().mockImplementation((_, val) => val);
+  return {
+    wrap: mockWrap,
+    extract: mockExtract,
+  };
+});
+
+jest.mock("./trace-context-service", () => {
+  class MockTraceContextService {
+    get traceSource() {
+      return mockTraceSource;
+    }
+    get currentTraceHeaders() {
+      return mockTraceHeaders;
+    }
+  }
+  return {
+    TraceContextService: MockTraceContextService,
+  };
+});
+
+describe("TraceListener", () => {
+  const defaultConfig = { autoPatchHTTP: true, mergeDatadogXrayTraces: false };
+  const context = {
+    invokedFunctionArn: "arn:aws:lambda:us-east-1:123456789101:function:my-lambda",
+    awsRequestId: "1234",
+    functionName: "my-lambda",
+  };
+  beforeEach(() => {
+    mockWrap.mockClear();
+    mockExtract.mockClear();
+    mockTraceHeaders = undefined;
+    mockTraceSource = undefined;
+  });
+
+  it("wraps dd-trace span around invocation", async () => {
+    const listener = new TraceListener(defaultConfig, "handler.my-handler");
+    listener.onStartInvocation({}, context as any);
+    const unwrappedFunc = () => {};
+    const wrappedFunc = listener.onWrap(unwrappedFunc);
+    wrappedFunc();
+    await listener.onCompleteInvocation();
+
+    expect(mockWrap).toHaveBeenCalledWith(
+      "aws.lambda",
+      {
+        resource: "handler.my-handler",
+        tags: {
+          cold_start: true,
+          function_arn: "arn:aws:lambda:us-east-1:123456789101:function:my-lambda",
+          request_id: "1234",
+          resource_names: "my-lambda",
+        },
+      },
+      unwrappedFunc,
+    );
+  });
+
+  it("wraps dd-trace span around invocation, with trace context from event", async () => {
+    const listener = new TraceListener(defaultConfig, "handler.my-handler");
+    mockTraceHeaders = {
+      "x-datadog-parent-id": "797643193680388251",
+      "x-datadog-sampling-priority": "2",
+      "x-datadog-trace-id": "4110911582297405551",
+    };
+    mockTraceSource = Source.Event;
+    listener.onStartInvocation({}, context as any);
+    const unwrappedFunc = () => {};
+    const wrappedFunc = listener.onWrap(unwrappedFunc);
+    wrappedFunc();
+    await listener.onCompleteInvocation();
+
+    expect(mockWrap).toHaveBeenCalledWith(
+      "aws.lambda",
+      {
+        resource: "handler.my-handler",
+        tags: {
+          cold_start: true,
+          function_arn: "arn:aws:lambda:us-east-1:123456789101:function:my-lambda",
+          request_id: "1234",
+          resource_names: "my-lambda",
+        },
+        childOf: mockTraceHeaders,
+      },
+      unwrappedFunc,
+    );
+  });
+
+  it("wraps dd-trace span around invocation, without trace context from xray", async () => {
+    const listener = new TraceListener(defaultConfig, "handler.my-handler");
+    mockTraceHeaders = {
+      "x-datadog-parent-id": "797643193680388251",
+      "x-datadog-sampling-priority": "2",
+      "x-datadog-trace-id": "4110911582297405551",
+    };
+    mockTraceSource = Source.Xray;
+
+    listener.onStartInvocation({}, context as any);
+    const unwrappedFunc = () => {};
+    const wrappedFunc = listener.onWrap(unwrappedFunc);
+    wrappedFunc();
+    await listener.onCompleteInvocation();
+
+    expect(mockWrap).toHaveBeenCalledWith(
+      "aws.lambda",
+      {
+        resource: "handler.my-handler",
+        tags: {
+          cold_start: true,
+          function_arn: "arn:aws:lambda:us-east-1:123456789101:function:my-lambda",
+          request_id: "1234",
+          resource_names: "my-lambda",
+        },
+      },
+      unwrappedFunc,
+    );
+  });
+
+  it("wraps dd-trace span around invocation, with trace context from xray when mergeDatadogXrayTraces is enabled", async () => {
+    const listener = new TraceListener({ ...defaultConfig, mergeDatadogXrayTraces: true }, "handler.my-handler");
+    mockTraceHeaders = {
+      "x-datadog-parent-id": "797643193680388251",
+      "x-datadog-sampling-priority": "2",
+      "x-datadog-trace-id": "4110911582297405551",
+    };
+    mockTraceSource = Source.Xray;
+
+    listener.onStartInvocation({}, context as any);
+    const unwrappedFunc = () => {};
+    const wrappedFunc = listener.onWrap(unwrappedFunc);
+    wrappedFunc();
+    await listener.onCompleteInvocation();
+
+    expect(mockWrap).toHaveBeenCalledWith(
+      "aws.lambda",
+      {
+        resource: "handler.my-handler",
+        tags: {
+          cold_start: true,
+          function_arn: "arn:aws:lambda:us-east-1:123456789101:function:my-lambda",
+          request_id: "1234",
+          resource_names: "my-lambda",
+        },
+        childOf: mockTraceHeaders,
+      },
+      unwrappedFunc,
+    );
+  });
+});

--- a/src/trace/listener.ts
+++ b/src/trace/listener.ts
@@ -5,10 +5,10 @@ import { extractTraceContext, readStepFunctionContextFromEvent, StepFunctionCont
 import { patchHttp, unpatchHttp } from "./patch-http";
 import { TraceContextService } from "./trace-context-service";
 
+import { logDebug } from "../utils";
 import { didFunctionColdStart } from "../utils/cold-start";
 import { Source } from "./constants";
 import { isTracerInitialized } from "./dd-trace-utils";
-import { logDebug } from "utils";
 
 export interface TraceConfig {
   /**
@@ -62,8 +62,8 @@ export class TraceListener {
       logDebug("Attempting to find parent for datadog trace trace");
     } else {
       logDebug("Didn't attempt to find parent for datadog trace", {
-        traceSource: this.contextService.traceSource,
         mergeDatadogXrayTraces: this.config.mergeDatadogXrayTraces,
+        traceSource: this.contextService.traceSource,
       });
     }
 

--- a/src/trace/listener.ts
+++ b/src/trace/listener.ts
@@ -7,6 +7,7 @@ import { TraceContextService } from "./trace-context-service";
 
 import { didFunctionColdStart } from "../utils/cold-start";
 import { Source } from "./constants";
+import { isTracerInitialised } from "./dd-trace-utils";
 
 export interface TraceConfig {
   /**
@@ -32,7 +33,7 @@ export class TraceListener {
   constructor(private config: TraceConfig, private handlerName: string) {}
 
   public onStartInvocation(event: any, context: Context) {
-    if (this.config.autoPatchHTTP) {
+    if (this.config.autoPatchHTTP && !isTracerInitialised()) {
       patchHttp(this.contextService);
     }
     this.context = context;

--- a/src/trace/listener.ts
+++ b/src/trace/listener.ts
@@ -86,7 +86,6 @@ export class TraceListener {
     }
 
     if (spanContext !== null) {
-      logDebug("Parenting datadog trace", { traceId: spanContext.toTraceId(), spanId: spanContext.toSpanId() });
       options.childOf = spanContext;
     }
     options.resource = this.handlerName;

--- a/src/trace/patch-http.spec.ts
+++ b/src/trace/patch-http.spec.ts
@@ -4,7 +4,7 @@ import nock from "nock";
 import { parse } from "url";
 
 import { LogLevel, setLogLevel } from "../utils";
-import { parentIDHeader, SampleMode, samplingPriorityHeader, traceIDHeader } from "./constants";
+import { parentIDHeader, SampleMode, samplingPriorityHeader, traceIDHeader, Source } from "./constants";
 import { patchHttp, unpatchHttp } from "./patch-http";
 import { TraceContextService } from "./trace-context-service";
 
@@ -23,6 +23,7 @@ describe("patchHttp", () => {
     contextService.rootTraceContext = {
       parentID: "78910",
       sampleMode: SampleMode.USER_KEEP,
+      source: Source.Event,
       traceID: "123456",
     };
     setLogLevel(LogLevel.NONE);

--- a/src/trace/trace-context-service.ts
+++ b/src/trace/trace-context-service.ts
@@ -48,4 +48,8 @@ export class TraceContextService {
       [samplingPriorityHeader]: this.currentTraceContext.sampleMode.toString(10),
     };
   }
+
+  get traceSource() {
+    return this.rootTraceContext !== undefined ? this.rootTraceContext.source : undefined;
+  }
 }


### PR DESCRIPTION
### What does this PR do?

Fixes some edge cases with our dd-trace-js integration.
1. Disables datadog-lambda-layer-js patching of http libraries, if the datadog tracer has been initialized
2. By default disables parenting datadog traces to X-Ray traces. There is a new config option, (mergeDatadogXrayTraces), which must be true, before the old behaviour is used. Note, this doesn't disable distributed tracing, which still works the same as before.
