### PR TITLE
Add missing call to setColdStart

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,7 @@ import {
   MetricsListener,
 } from "./metrics";
 import { TraceConfig, TraceHeaders, TraceListener } from "./trace";
-import { logError, LogLevel, setLogLevel, wrap } from "./utils";
-import { setColdStart } from "utils/cold-start";
+import { logError, LogLevel, setColdStart, setLogLevel, wrap } from "./utils";
 
 export { TraceHeaders } from "./trace";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {
 } from "./metrics";
 import { TraceConfig, TraceHeaders, TraceListener } from "./trace";
 import { logError, LogLevel, setLogLevel, wrap } from "./utils";
+import { setColdStart } from "utils/cold-start";
 
 export { TraceHeaders } from "./trace";
 
@@ -74,6 +75,7 @@ export function datadog<TEvent, TResult>(
   return wrap(
     handler,
     (event, context) => {
+      setColdStart();
       setLogLevel(finalConfig.debugLogging ? LogLevel.DEBUG : LogLevel.ERROR);
       currentMetricsListener = metricsListener;
       currentTraceListener = traceListener;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+export { didFunctionColdStart, getColdStartTag, setColdStart } from "./cold-start";
 export { wrap } from "./handler";
 export { Timer } from "./timer";
 export { logError, logDebug, setLogLevel, LogLevel } from "./log";


### PR DESCRIPTION
### What does this PR do?

Noticed we were missing a call to setColdStart() in the wrapper, so enhanced metrics may have been reporting incorrectly for node.
