### PR TITLE
Modify dd trace version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,8 @@ version: 2.1
 
 jobs:
   verify_build:
+    environment:
+      NODE_OPTIONS: --max_old_space_size=4096
     working_directory: ~/repo
     docker:
       - image: circleci/node:<< parameters.node >>

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "aws-xray-sdk-core": "^2.5.0",
     "bignumber.js": "^9.0.0",
-    "dd-trace": "0.17.0-beta.3",
+    "dd-trace": "^0.17.0-beta.1",
     "promise-retry": "^1.1.1",
     "shimmer": "^1.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datadog-lambda-js",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Lambda client library that supports hybrid tracing in node js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1041,10 +1041,10 @@ date-fns@^1.29.0:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-dd-trace@0.17.0-beta.3:
-  version "0.17.0-beta.3"
-  resolved "https://registry.yarnpkg.com/dd-trace/-/dd-trace-0.17.0-beta.3.tgz#47ac808696868c9d049eeaaa0fb337fde34f0366"
-  integrity sha512-nWWEdR32bHN8lzGy88mRTsGGSif5vQIhXn1Tb9pokszHXFPCrfmpjemcBDbUhIMbWX04K5Py7Xp27C+UPlhoCA==
+dd-trace@^0.17.0-beta.1:
+  version "0.17.0-beta.11"
+  resolved "https://registry.yarnpkg.com/dd-trace/-/dd-trace-0.17.0-beta.11.tgz#9e625546f854dd3fe329a293cafe3ca23f13227d"
+  integrity sha512-Px+8s2szPwW9DDVrbmhs2cJb+/Mti4FvAlIJUwwl6kTf107X6T//nQLU+qv9aqinDdM2AR+J3IZjSEfVhwWjrw==
   dependencies:
     "@types/node" "^10.12.18"
     bowser "^2.5.3"


### PR DESCRIPTION
### What does this PR do?

Uses a looser version requirement for dd-trace-js. This reduces the chance of a customer using a duplicate copy of the repository, and causing the wrapping code to fail.
