### PR TITLE
Fix timestamps for async metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datadog-lambda-js",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Lambda client library that supports hybrid tracing in node js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/metrics/build-metric-log.spec.ts
+++ b/src/metrics/build-metric-log.spec.ts
@@ -1,0 +1,15 @@
+import { buildMetricLog } from "./build-metric-log";
+
+describe("buildMetricLog", () => {
+  jest.spyOn(Date, "now").mockImplementation(() => 1487076708123);
+  it("handles empty tag list", () => {
+    expect(buildMetricLog("my.test.metric", 1337, [])).toStrictEqual(
+      '{"e":1487076708.123,"m":"my.test.metric","t":[],"v":1337}\n',
+    );
+  });
+  it("writes timestamp in Unix seconds", () => {
+    expect(buildMetricLog("my.test.metric", 1337, ["region:us", "account:dev", "team:serverless"])).toStrictEqual(
+      '{"e":1487076708.123,"m":"my.test.metric","t":["region:us","account:dev","team:serverless"],"v":1337}\n',
+    );
+  });
+});

--- a/src/metrics/build-metric-log.ts
+++ b/src/metrics/build-metric-log.ts
@@ -1,0 +1,10 @@
+// Builds the string representation of the metric that will be written to logs
+export function buildMetricLog(name: string, value: number, tags: string[]) {
+  return `${JSON.stringify({
+    // Date.now() returns Unix time in milliseconds, we convert to seconds for DD API submission
+    e: Date.now() / 1000,
+    m: name,
+    t: tags,
+    v: value,
+  })}\n`;
+}

--- a/src/metrics/listener.spec.ts
+++ b/src/metrics/listener.spec.ts
@@ -98,6 +98,6 @@ describe("MetricsListener", () => {
     listener.sendDistributionMetric("my-metric", 10, "tag:a", "tag:b");
     await listener.onCompleteInvocation();
 
-    expect(spy).toHaveBeenCalledWith(`{"e":1487076708000,"m":"my-metric","t":["tag:a","tag:b"],"v":10}\n`);
+    expect(spy).toHaveBeenCalledWith(`{"e":1487076708,"m":"my-metric","t":["tag:a","tag:b"],"v":10}\n`);
   });
 });

--- a/src/metrics/listener.ts
+++ b/src/metrics/listener.ts
@@ -2,6 +2,7 @@ import { promisify } from "util";
 
 import { logDebug, logError } from "../utils";
 import { APIClient } from "./api";
+import { buildMetricLog } from "./build-metric-log";
 import { KMSService } from "./kms-service";
 import { Distribution } from "./model";
 import { Processor } from "./processor";
@@ -86,14 +87,7 @@ export class MetricsListener {
     if (this.config.logForwarding) {
       // We use process.stdout.write, because console.log will prepend metadata to the start
       // of the log that log forwarder doesn't know how to read.
-      process.stdout.write(
-        `${JSON.stringify({
-          e: Date.now(),
-          m: name,
-          t: tags,
-          v: value,
-        })}\n`,
-      );
+      process.stdout.write(buildMetricLog(name, value, tags));
       return;
     }
     const dist = new Distribution(name, [{ timestamp: new Date(), value }], ...tags);


### PR DESCRIPTION
### What does this PR do?

Fixes the listener to log async metrics with Unix second timestamps rather than the milliseconds that it's currently using. The DD API accepts seconds only so this is causing issues with async metrics when submitted in the log forwarder.

### Testing Guidelines

Deployed and tested the layer in staging env and added new unit tests for the metric log generating code.
