### PR TITLE
Don't unpatch HTTP lib if the Datadog tracer is initialized

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datadog-lambda-js",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "description": "Lambda client library that supports hybrid tracing in node js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/trace/listener.ts
+++ b/src/trace/listener.ts
@@ -50,6 +50,7 @@ export class TraceListener {
       logDebug("Didn't patch console output with trace context");
     }
 
+    // If the DD tracer is initialized then it's doing http patching so we don't again here
     if (this.config.autoPatchHTTP && !tracerInitialized) {
       logDebug("Patching HTTP libraries");
       patchHttp(this.contextService);
@@ -63,7 +64,9 @@ export class TraceListener {
   }
 
   public async onCompleteInvocation() {
-    if (this.config.autoPatchHTTP) {
+    // If the DD tracer is initialized it manages patching of the http lib on its own
+    const tracerInitialized = this.tracerWrapper.isTracerAvailable;
+    if (this.config.autoPatchHTTP && !tracerInitialized) {
       logDebug("Unpatching HTTP libraries");
       unpatchHttp();
     }


### PR DESCRIPTION
### What does this PR do?

Prevents the layer from unpatching the http lib when the DD tracer is present. When the DD tracer is initialized it handles patching/unpatching on its own.

### Motivation

Unpatching the http lib after function invocations complete was causing the layer to remove the patching that the DD tracer was doing, resulting in correct traces for cold starts but missing HTTP request spans in subsequent executions.

### Testing Guidelines

Tested the new version of the layer with our test Lambdas and confirmed that the issue was fixed.
