### PR TITLE
Make getEnhancedMetricTags() works for local invocation

### DIFF
--- a/src/metrics/enhanced-metrics.spec.ts
+++ b/src/metrics/enhanced-metrics.spec.ts
@@ -12,6 +12,10 @@ const mockContext = ({
   invokedFunctionArn: mockARN,
   memoryLimitInMB: "128",
 } as any) as Context;
+const mockContextLocal = ({
+  functionName: "my-test-lambda",
+  memoryLimitInMB: "128",
+} as any) as Context;
 
 describe("getRuntimeTag", () => {
   it("returns a null runtime tag when version is not recognized", () => {
@@ -48,6 +52,16 @@ describe("getEnhancedMetricTags", () => {
     expect(getEnhancedMetricTags(mockContext)).toStrictEqual([
       "region:us-east-1",
       "account_id:123497598159",
+      "functionname:my-test-lambda",
+      "cold_start:true",
+      "memorysize:128",
+      "runtime:nodejs8.10",
+    ]);
+  });
+
+  it("generates tag list with local runtime", () => {
+    mockedGetProcessVersion.mockReturnValue("v8.10.0");
+    expect(getEnhancedMetricTags(mockContextLocal)).toStrictEqual([
       "functionname:my-test-lambda",
       "cold_start:true",
       "memorysize:128",

--- a/src/metrics/enhanced-metrics.ts
+++ b/src/metrics/enhanced-metrics.ts
@@ -44,11 +44,11 @@ export function getRuntimeTag(): string | null {
 }
 
 export function getEnhancedMetricTags(context: Context): string[] {
-  const tags = [
-    ...parseTagsFromARN(context.invokedFunctionArn),
-    getColdStartTag(),
-    `memorysize:${context.memoryLimitInMB}`,
-  ];
+  let arnTags = [`functionname:${context.functionName}`];
+  if (context.invokedFunctionArn) {
+    arnTags = parseTagsFromARN(context.invokedFunctionArn);
+  }
+  const tags = [...arnTags, getColdStartTag(), `memorysize:${context.memoryLimitInMB}`];
 
   const runtimeTag = getRuntimeTag();
   if (runtimeTag) {


### PR DESCRIPTION
### What does this PR do?

When we run local invocation using Serverless framework, the `invokedFunctionArn` context value is undefined.

### Motivation

I really want to test all my lambda in local mode, even if it's very difficult, it's so important to me.

### Testing Guidelines

Run a lambda using invoke command locally of the serverless framework with datadog wrapper.
