### PR TITLE
Be able to provide custom logger to replace console usage

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -323,4 +323,20 @@ describe("datadog", () => {
     expect(mockedIncrementInvocations).toBeCalledTimes(0);
     expect(mockedIncrementErrors).toBeCalledTimes(0);
   });
+
+  it("use custom logger to log debug messages", async () => {
+    const logger = {
+      debug: jest.fn(),
+      error: jest.fn(),
+    };
+
+    const wrapped = datadog(handler, { forceWrap: true, logger: logger, debugLogging: true });
+
+    await wrapped({}, mockContext, () => {});
+
+    expect(mockedIncrementInvocations).toBeCalledTimes(1);
+    expect(mockedIncrementInvocations).toBeCalledWith(mockContext);
+    expect(logger.debug).toHaveBeenCalledTimes(5);
+    expect(logger.debug).toHaveBeenLastCalledWith('{"status":"debug","message":"datadog:Unpatching HTTP libraries"}');
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import {
   MetricsListener,
 } from "./metrics";
 import { TraceConfig, TraceHeaders, TraceListener } from "./trace";
-import { logError, LogLevel, setColdStart, setLogLevel, setLogger, wrap } from "./utils";
+import { logError, LogLevel, Logger, setColdStart, setLogLevel, setLogger, wrap } from "./utils";
 
 export { TraceHeaders } from "./trace";
 
@@ -36,7 +36,7 @@ interface GlobalConfig {
   /**
    * Custom logger.
    */
-  logger?: any;
+  logger?: Logger;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import {
   MetricsListener,
 } from "./metrics";
 import { TraceConfig, TraceHeaders, TraceListener } from "./trace";
-import { logError, LogLevel, setColdStart, setLogLevel, wrap } from "./utils";
+import { logError, LogLevel, setColdStart, setLogLevel, setLogger, wrap } from "./utils";
 
 export { TraceHeaders } from "./trace";
 
@@ -33,6 +33,10 @@ interface GlobalConfig {
    * @default false
    */
   forceWrap: boolean;
+  /**
+   * Custom logger.
+   */
+  logger?: any;
 }
 
 /**
@@ -90,6 +94,9 @@ export function datadog<TEvent, TResult>(
     (event, context) => {
       setColdStart();
       setLogLevel(finalConfig.debugLogging ? LogLevel.DEBUG : LogLevel.ERROR);
+      if (finalConfig.logger) {
+        setLogger(finalConfig.logger);
+      }
       currentMetricsListener = metricsListener;
       currentTraceListener = traceListener;
       // Setup hook, (called once per handler invocation)

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,4 @@
 export { didFunctionColdStart, getColdStartTag, setColdStart } from "./cold-start";
 export { wrap } from "./handler";
 export { Timer } from "./timer";
-export { logError, logDebug, setLogLevel, setLogger, LogLevel } from "./log";
+export { logError, logDebug, Logger, setLogLevel, setLogger, LogLevel } from "./log";

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,4 @@
 export { didFunctionColdStart, getColdStartTag, setColdStart } from "./cold-start";
 export { wrap } from "./handler";
 export { Timer } from "./timer";
-export { logError, logDebug, setLogLevel, LogLevel } from "./log";
+export { logError, logDebug, setLogLevel, setLogger, LogLevel } from "./log";

--- a/src/utils/log.spec.ts
+++ b/src/utils/log.spec.ts
@@ -1,0 +1,15 @@
+import { setLogger, logError } from "./log";
+
+describe("logger", () => {
+  it("log using custom logger", async () => {
+    const logger = {
+      debug: jest.fn(),
+      error: jest.fn(),
+    };
+
+    setLogger(logger);
+    logError("My Error");
+
+    expect(logger.error).toHaveBeenLastCalledWith('{"status":"error","message":"datadog:My Error"}');
+  });
+});

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -4,7 +4,12 @@ export enum LogLevel {
   NONE,
 }
 
+let logger = console;
 let logLevel = LogLevel.ERROR;
+
+export function setLogger(customLogger: any) {
+  logger = customLogger;
+}
 
 export function setLogLevel(level: LogLevel) {
   logLevel = level;
@@ -20,9 +25,9 @@ export function logDebug(message: string, metadata?: object) {
   }
   message = `datadog:${message}`;
   if (metadata === undefined) {
-    console.debug(JSON.stringify({ status: "debug", message }));
+    logger.debug(JSON.stringify({ status: "debug", message }));
   } else {
-    console.debug(JSON.stringify({ ...metadata, status: "debug", message }));
+    logger.debug(JSON.stringify({ ...metadata, status: "debug", message }));
   }
 }
 
@@ -32,8 +37,8 @@ export function logError(message: string, metadata?: object) {
   }
   message = `datadog:${message}`;
   if (metadata === undefined) {
-    console.error(JSON.stringify({ status: "error", message }));
+    logger.error(JSON.stringify({ status: "error", message }));
   } else {
-    console.error(JSON.stringify({ ...metadata, status: "error", message }));
+    logger.error(JSON.stringify({ ...metadata, status: "error", message }));
   }
 }

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -4,10 +4,15 @@ export enum LogLevel {
   NONE,
 }
 
-let logger = console;
+export interface Logger {
+  debug(message: string): void;
+  error(message: string): void;
+}
+
+let logger: Logger = console;
 let logLevel = LogLevel.ERROR;
 
-export function setLogger(customLogger: any) {
+export function setLogger(customLogger: Logger) {
   logger = customLogger;
 }
 


### PR DESCRIPTION
### What does this PR do?

Add possibility to provide a custom logger object instead of `console` usage for `logError` and `logDebug`

### Motivation

I use Pino as logger in my lambda, so I wanted to format error and debug log from datadog lambda wrapper as my other logs

### Testing Guidelines

Pass a custom logger option and set log level as debug to see logs

### Additional Notes

~I will add tests and documentation if new feature is accepted~
Tests and documentation added