### PR TITLE
Lowercases function arn on dd-trace spans

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datadog-lambda-js",
-  "version": "2.21.0",
+  "version": "2.22.0",
   "description": "Lambda client library that supports hybrid tracing in node js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/trace/listener.ts
+++ b/src/trace/listener.ts
@@ -89,9 +89,10 @@ export class TraceListener {
     const options: TraceOptions = {};
     if (this.context) {
       logDebug("Applying lambda context to datadog traces");
+      const functionArn = (this.context.invokedFunctionArn ?? "").toLowerCase();
       options.tags = {
         cold_start: didFunctionColdStart(),
-        function_arn: this.context.invokedFunctionArn,
+        function_arn: functionArn,
         request_id: this.context.awsRequestId,
         resource_names: this.context.functionName,
       };


### PR DESCRIPTION
### What does this PR do?

Makes the dd-trace root span use a lowercase only function arn. This guarantees the trace will appear on the serverless traces page.
