### PR TITLE
Fix xray-sdk related errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "aws-xray-sdk-core": "^2.5.0",
+    "aws-xray-sdk-core": "^3.0.0",
     "bignumber.js": "^9.0.0",
     "promise-retry": "^1.1.1",
     "shimmer": "^1.2.1"

--- a/src/trace/constants.ts
+++ b/src/trace/constants.ts
@@ -17,3 +17,6 @@ export const xraySubsegmentKey = "trace";
 export const xrayBaggageSubsegmentKey = "root_span_metadata";
 export const xraySubsegmentNamespace = "datadog";
 export const xrayTraceEnvVar = "_X_AMZN_TRACE_ID";
+export const xrayUDPPort = 2000;
+export const localHost = "127.0.0.1";
+export const awsXrayDaemonAddressEnvVar = "AWS_XRAY_DAEMON_ADDRESS";

--- a/src/trace/constants.ts
+++ b/src/trace/constants.ts
@@ -17,6 +17,4 @@ export const xraySubsegmentKey = "trace";
 export const xrayBaggageSubsegmentKey = "root_span_metadata";
 export const xraySubsegmentNamespace = "datadog";
 export const xrayTraceEnvVar = "_X_AMZN_TRACE_ID";
-export const xrayUDPPort = 2000;
-export const localHost = "127.0.0.1";
 export const awsXrayDaemonAddressEnvVar = "AWS_XRAY_DAEMON_ADDRESS";

--- a/src/trace/context.spec.ts
+++ b/src/trace/context.spec.ts
@@ -1,5 +1,12 @@
 import { LogLevel, setLogLevel } from "../utils";
-import { SampleMode, xrayBaggageSubsegmentKey, xraySubsegmentNamespace, Source, xrayTraceEnvVar } from "./constants";
+import {
+  SampleMode,
+  xrayBaggageSubsegmentKey,
+  xraySubsegmentNamespace,
+  Source,
+  xrayTraceEnvVar,
+  awsXrayDaemonAddressEnvVar,
+} from "./constants";
 import {
   convertToAPMParentID,
   convertToAPMTraceID,
@@ -358,6 +365,7 @@ describe("readStepFunctionContextFromEvent", () => {
 describe("extractTraceContext", () => {
   afterEach(() => {
     process.env["_X_AMZN_TRACE_ID"] = undefined;
+    process.env[awsXrayDaemonAddressEnvVar] = undefined;
   });
   it("returns trace read from header as highest priority", () => {
     process.env["_X_AMZN_TRACE_ID"] = "Root=1-5ce31dc2-2c779014b90ce44db5e03875;Parent=0b11cc4230d3e09e;Sampled=1";
@@ -418,6 +426,7 @@ describe("extractTraceContext", () => {
     } as const;
     jest.spyOn(Date, "now").mockImplementation(() => 1487076708000);
     process.env[xrayTraceEnvVar] = "Root=1-5e272390-8c398be037738dc042009320;Parent=94ae789b969f1cc5;Sampled=1";
+    process.env[awsXrayDaemonAddressEnvVar] = "localhost:127.0.0.1:2000";
 
     extractTraceContext(stepFunctionEvent);
 

--- a/src/trace/context.ts
+++ b/src/trace/context.ts
@@ -124,7 +124,7 @@ export function sendXraySubsegment(segment: string) {
   if (xrayDaemonEnv !== undefined) {
     const parts = xrayDaemonEnv.split(":");
     if (parts.length > 1) {
-      port = parseInt(parts[1]);
+      port = parseInt(parts[1], 10);
       address = parts[0];
     }
   }

--- a/src/trace/trace-context-service.spec.ts
+++ b/src/trace/trace-context-service.spec.ts
@@ -5,12 +5,17 @@ import { SampleMode, Source } from "./constants";
 let mockXRaySegment: any;
 let mockXRayShouldThrow = false;
 jest.mock("aws-xray-sdk-core", () => {
+  let logger = { debug: () => {}, info: () => {}, error: () => {}, warn: () => {} };
   return {
     getSegment: () => {
       if (mockXRayShouldThrow) {
         throw new Error("Xray unitialised");
       }
       return mockXRaySegment;
+    },
+    getLogger: () => logger,
+    setLogger: (l: any) => {
+      logger = l;
     },
   };
 });

--- a/src/trace/trace-context-service.ts
+++ b/src/trace/trace-context-service.ts
@@ -13,13 +13,12 @@ export interface TraceHeaders {
   [parentIDHeader]: string;
   [samplingPriorityHeader]: string;
 }
-
-class NoopXrayLogger implements Logger {
-  warn(message: string) {}
-  debug(message: string) {}
-  info(message: string) {}
-  error(message: string) {}
-}
+const noopXrayLogger: Logger = {
+  warn: (message: string) => {},
+  debug: (message: string) => {},
+  info: (message: string) => {},
+  error: (message: string) => {},
+};
 
 /**
  * Service for retrieving the latest version of the request context from xray.
@@ -74,9 +73,9 @@ export class TraceContextService {
     // an exception or log a noisy output message when segment is empty.
     // We temporarily disabled logging on the library as a work around.
     const oldLogger = getLogger();
-    let xraySegment: Segment | undefined = undefined;
+    let xraySegment: Segment | undefined;
     try {
-      setLogger(new NoopXrayLogger());
+      setLogger(noopXrayLogger);
       xraySegment = getSegment();
     } catch (error) {}
     setLogger(oldLogger);

--- a/types/aws-xray-sdk-core/index.d.ts
+++ b/types/aws-xray-sdk-core/index.d.ts
@@ -9,6 +9,15 @@ declare module "aws-xray-sdk-core" {
     constructor(name: string, rootId: string, parentId: string);
     addMetadata(key: string, value: object | null, namespace?: string): void;
   }
+
+  export interface Logger {
+    error(message: string): void;
+    info(message: string): void;
+    warn(message: string): void;
+    debug(message: string): void;
+  }
   export function captureFunc(name: string, fcn: (segment: Segment) => void, parent?: Segment): void;
   export function getSegment(): Segment;
+  export function getLogger(): Logger;
+  export function setLogger(logger: Logger): void;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -377,17 +377,17 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/cls-hooked@*":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@types/cls-hooked/-/cls-hooked-4.3.0.tgz#290fa14946b88b11e65d68e487eda78a4d5a927e"
+  integrity sha512-H2ov/zMqgs7b66dkfufx3SXMnYFn6u9IOMEY7JZYWXJhE/WVZogedXsQIgM/504DyvtbNNXMiofaRr1E0+3yZA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
-
-"@types/continuation-local-storage@*":
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/@types/continuation-local-storage/-/continuation-local-storage-3.2.2.tgz#7cbf177a6206ece87bc4b808784772ad2aa5f6db"
-  integrity sha512-aItm+aYPJ4rT1cHmAxO+OdWjSviQ9iB5UKb5f0Uvgln0N4hS2mcDodHtPiqicYBXViUYhqyBjhA5uyOcT+S34Q==
-  dependencies:
-    "@types/node" "*"
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.1"
@@ -608,18 +608,12 @@ astral-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
-async-listener@^0.6.0:
-  version "0.6.10"
-  resolved "https://registry.yarnpkg.com/async-listener/-/async-listener-0.6.10.tgz#a7c97abe570ba602d782273c0de60a51e3e17cbc"
-  integrity sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==
+async-hook-jl@^1.7.6:
+  version "1.7.6"
+  resolved "https://registry.yarnpkg.com/async-hook-jl/-/async-hook-jl-1.7.6.tgz#4fd25c2f864dbaf279c610d73bf97b1b28595e68"
+  integrity sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==
   dependencies:
-    semver "^5.3.0"
-    shimmer "^1.1.0"
-
-async@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-1.0.0.tgz#f8fc04ca3a13784ade9e1641af98578cfbd647a9"
-  integrity sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=
+    stack-chain "^1.3.7"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -636,7 +630,7 @@ atomic-batcher@^1.0.2:
   resolved "https://registry.yarnpkg.com/atomic-batcher/-/atomic-batcher-1.0.2.tgz#d16901d10ccec59516c197b9ccd8930689b813b4"
   integrity sha1-0WkB0QzOxZUWwZe5zNiTBom4E7Q=
 
-aws-sdk@*, aws-sdk@^2.304.0:
+aws-sdk@*:
   version "2.639.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.639.0.tgz#ae887a179939750de240ddeb680668300256900f"
   integrity sha512-cbH69oV0ObZ4tapbjDqu0j3I779uscQNhRaewjIJY5O5At4RULtd7us24n72FtT4HIwM9cwORzVxA9rK6DHKOA==
@@ -656,19 +650,16 @@ aws-sign2@~0.7.0:
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
   integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
 
-aws-xray-sdk-core@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/aws-xray-sdk-core/-/aws-xray-sdk-core-2.5.0.tgz#4e6f12627ddfac1c8fd73d915771cb7669977c38"
-  integrity sha512-qe60bv0kn5KY6gAIF88TPCOIdu/A3dTmcKISj+kE4OH02eF6kMm1ctL7OgoBAasnsDNSn0VMLhIaA1izgoWuxA==
+aws-xray-sdk-core@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/aws-xray-sdk-core/-/aws-xray-sdk-core-3.0.0.tgz#2a680c8e6f9dfdcab130ff14b98d6101e5b46646"
+  integrity sha512-RzH0GmOdMLqzpa673PZiPNZT/WlJp/8KbB3Bt2I6uLBwndz87c2z79BeEhPV1MLW4B3BfDb0AKoAPccBY5kAUQ==
   dependencies:
-    "@types/continuation-local-storage" "*"
+    "@types/cls-hooked" "*"
     atomic-batcher "^1.0.2"
-    aws-sdk "^2.304.0"
-    continuation-local-storage "^3.2.0"
-    date-fns "^1.29.0"
+    cls-hooked "^4.2.2"
     pkginfo "^0.4.0"
     semver "^5.3.0"
-    winston "^2.4.4"
 
 aws4@^1.8.0:
   version "1.9.1"
@@ -914,6 +905,15 @@ cliui@^6.0.0:
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
 
+cls-hooked@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/cls-hooked/-/cls-hooked-4.2.2.tgz#ad2e9a4092680cdaffeb2d3551da0e225eae1908"
+  integrity sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==
+  dependencies:
+    async-hook-jl "^1.7.6"
+    emitter-listener "^1.0.1"
+    semver "^5.4.1"
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -956,11 +956,6 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-colors@1.0.x:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
-  integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
-
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
@@ -987,14 +982,6 @@ container-info@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/container-info/-/container-info-1.0.1.tgz#6b383cb5e197c8d921e88983388facb04124b56b"
   integrity sha512-wk/+uJvPHOFG+JSwQS+fw6H6yw3Oyc8Kw9L4O2MN817uA90OqJ59nlZbbLPqDudsjJ7Tetee3pwExdKpd2ahjQ==
-
-continuation-local-storage@^3.2.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz#11f613f74e914fe9b34c92ad2d28fe6ae1db7ffb"
-  integrity sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==
-  dependencies:
-    async-listener "^0.6.0"
-    emitter-listener "^1.1.1"
 
 convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.7.0"
@@ -1055,11 +1042,6 @@ cssstyle@^2.0.0:
   dependencies:
     cssom "~0.3.6"
 
-cycle@1.0.x:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/cycle/-/cycle-1.0.3.tgz#21e80b2be8580f98b468f379430662b046c34ad2"
-  integrity sha1-IegLK+hYD5i0aPN5QwZisEbDStI=
-
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -1075,11 +1057,6 @@ data-urls@^1.1.0:
     abab "^2.0.0"
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
-
-date-fns@^1.29.0:
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
-  integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
 dd-trace@0.20.0-beta.0:
   version "0.20.0-beta.0"
@@ -1208,7 +1185,7 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-emitter-listener@^1.1.1:
+emitter-listener@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/emitter-listener/-/emitter-listener-1.1.2.tgz#56b140e8f6992375b3d7cb2cab1cc7432d9632e8"
   integrity sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==
@@ -1414,11 +1391,6 @@ extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
-
-eyes@0.1.x:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
-  integrity sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=
 
 fast-deep-equal@^3.1.1:
   version "3.1.1"
@@ -1913,7 +1885,7 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
-isstream@0.1.x, isstream@~0.1.2:
+isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
@@ -3415,7 +3387,7 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-shimmer@^1.1.0, shimmer@^1.2.0, shimmer@^1.2.1:
+shimmer@^1.2.0, shimmer@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/shimmer/-/shimmer-1.2.1.tgz#610859f7de327b587efebf501fb43117f9aff337"
   integrity sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==
@@ -3557,10 +3529,10 @@ sshpk@^1.7.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
-stack-trace@0.0.x:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
-  integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
+stack-chain@^1.3.7:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/stack-chain/-/stack-chain-1.3.7.tgz#d192c9ff4ea6a22c94c4dd459171e3f00cea1285"
+  integrity sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU=
 
 stack-utils@^1.0.1:
   version "1.0.2"
@@ -4032,18 +4004,6 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
-
-winston@^2.4.4:
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/winston/-/winston-2.4.4.tgz#a01e4d1d0a103cf4eada6fc1f886b3110d71c34b"
-  integrity sha512-NBo2Pepn4hK4V01UfcWcDlmiVTs7VTB1h7bgnB0rgP146bYhMxX0ypCz3lBOfNxCO4Zuek7yeT+y/zM1OfMw4Q==
-  dependencies:
-    async "~1.0.0"
-    colors "1.0.x"
-    cycle "1.0.x"
-    eyes "0.1.x"
-    isstream "0.1.x"
-    stack-trace "0.0.x"
 
 word-wrap@~1.2.3:
   version "1.2.3"


### PR DESCRIPTION
### What does this PR do?
New version of the xray sdk had significant behaviour changes. Unless initialized, getSegment  and captureFunc would throw an error or log, instead of returning empty. The getSegment call was particularly bad, because it occurred during the patched console.log method, and could generate an infinite loop. This PR:

1. Fixes the console.log issue, by disabling the xray logger temporarily while calling getSegment, catching any errors and also adding a re-entrance check to the patched function. 
1. Removes the captureFunc call used to add datadog metadata to the x-ray trace, and replaces it by calling the daemon directly.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

How did you test this pull request?

### Additional Notes

Anything else we should know when reviewing?
