### PR TITLE
Serialize-error package wrong version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "aws-xray-sdk-core": "^3.0.0",
     "bignumber.js": "^9.0.0",
     "promise-retry": "^1.1.1",
-    "serialize-error": "true7.0.1",
+    "serialize-error": "^7.0.1",
     "shimmer": "^1.2.1"
   },
   "jest": {


### PR DESCRIPTION
Serialize-error package wrong version causing the issue refer https://github.com/DataDog/datadog-lambda-layer-js/issues/81

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-layer-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds appropriate version on one of the dependecies.

### Motivation

My application build is failing due to this issue caused me to raise this PR

### Testing Guidelines

I have just changed the version number to its equivalent NPM version. A DataDog member can test this as required.



### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
